### PR TITLE
Add redux dev tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@node-rs/argon2": "^1.6.0",
+        "@redux-devtools/extension": "^3.3.0",
         "axios": "^1.6.3",
         "bcryptjs": "^2.4.3",
         "connect-ensure-login": "^0.1.1",
@@ -976,6 +977,18 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@redux-devtools/extension": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@redux-devtools/extension/-/extension-3.3.0.tgz",
+      "integrity": "sha512-X34S/rC8S/M1BIrkYD1mJ5f8vlH0BDqxXrs96cvxSBo4FhMdbhU+GUGsmNYov1xjSyLMHgo8NYrUG8bNX7525g==",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2",
+        "immutable": "^4.3.4"
+      },
+      "peerDependencies": {
+        "redux": "^3.1.0 || ^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/@redux-saga/core": {
@@ -4184,6 +4197,11 @@
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true
+    },
+    "node_modules/immutable": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
+      "integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA=="
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@node-rs/argon2": "^1.6.0",
+    "@redux-devtools/extension": "^3.3.0",
     "axios": "^1.6.3",
     "bcryptjs": "^2.4.3",
     "connect-ensure-login": "^0.1.1",

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,4 +1,4 @@
-import { composeWithDevTools } from '@redux-devtools/extension'
+import { composeWithDevToolsDevelopmentOnly } from '@redux-devtools/extension'
 import { applyMiddleware, legacy_createStore as createStore } from 'redux'
 import logger from 'redux-logger'
 import createSagaMiddleware from 'redux-saga'
@@ -7,19 +7,13 @@ import rootSaga from './sagas'
 
 const saga = createSagaMiddleware()
 
-// Check if we're in development, and if not, don't include the redux dev tools
-// A lot of sites include it in production (which is *extremely* funny), but
-// it's definitely not necessary.
-// Info on the dev tools: https://github.com/reduxjs/redux-devtools
-const nodeenv = process.env['NODE_ENV'] || 'development'
-const enhancers =
-  nodeenv === 'development'
-    ? composeWithDevTools(applyMiddleware(saga, logger))
-    : applyMiddleware(saga)
-
 // Creates a redux store with our reducers, middleware, and if in development,
 // the redux dev tools.
-const store = createStore(rootReducer, enhancers)
+const store = createStore(
+  rootReducer,
+  // Excludes dev tools in production
+  composeWithDevToolsDevelopmentOnly(applyMiddleware(saga, logger)),
+)
 
 // tells the saga middleware to use the rootSaga
 // rootSaga contains all of our other sagas

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,3 +1,4 @@
+import { composeWithDevTools } from '@redux-devtools/extension'
 import { applyMiddleware, legacy_createStore as createStore } from 'redux'
 import logger from 'redux-logger'
 import createSagaMiddleware from 'redux-saga'
@@ -6,19 +7,19 @@ import rootSaga from './sagas'
 
 const saga = createSagaMiddleware()
 
-// this line creates an array of all of redux middleware you want to use
-// we don't want a whole ton of console logs in our production code
-// logger will only be added to your project if your in development mode
-// const middlewareList =
-//   process.env.NODE_ENV === 'development' ? [saga, logger] : [saga]
+// Check if we're in development, and if not, don't include the redux dev tools
+// A lot of sites include it in production (which is *extremely* funny), but
+// it's definitely not necessary.
+// Info on the dev tools: https://github.com/reduxjs/redux-devtools
+const nodeenv = process.env['NODE_ENV'] || 'development'
+const enhancers =
+  nodeenv === 'development'
+    ? composeWithDevTools(applyMiddleware(saga, logger))
+    : applyMiddleware(saga)
 
-const store = createStore(
-  // tells the saga middleware to use the rootReducer
-  // rootSaga contains all of our other reducers
-  rootReducer,
-  // adds all middleware to our project including saga and logger
-  applyMiddleware(saga, logger),
-)
+// Creates a redux store with our reducers, middleware, and if in development,
+// the redux dev tools.
+const store = createStore(rootReducer, enhancers)
 
 // tells the saga middleware to use the rootSaga
 // rootSaga contains all of our other sagas


### PR DESCRIPTION
Only should end up running in development

There's a high probability that the redux logger will have to be removed (in order to switch to redux 9 and such), so having some dev tools would be helpful.
The redux dev tools themselves are incredibly powerful, so it feels like the most sensible choice for that.

Info on the redux dev tools: https://github.com/reduxjs/redux-devtools
Firefox Addon: https://addons.mozilla.org/en-US/firefox/addon/reduxdevtools/